### PR TITLE
Change types to base what `visitor` gets on `tree`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
-*.d.ts
+color.browser.d.ts
+color.d.ts
+index.d.ts
+test.d.ts
 *.log
 coverage/
 node_modules/

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -1,4 +1,7 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
 import type {Node, Parent} from 'unist'
+import type {Test} from 'unist-util-is'
 
 export type InclusiveDescendant<
   Tree extends Node = never,
@@ -11,3 +14,38 @@ export type InclusiveDescendant<
           Found | Tree
         >
   : Tree
+
+type Predicate<Fn, Fallback = never> = Fn extends (
+  value: any
+) => value is infer Thing
+  ? Thing
+  : Fallback
+
+type MatchesOne<Value, Check> =
+  // Is this a node?
+  Value extends Node
+    ? // No test.
+      Check extends null
+      ? Value
+      : // No test.
+      Check extends undefined
+      ? Value
+      : // Function test.
+      Check extends Function
+      ? Extract<Value, Predicate<Check, Value>>
+      : // String (type) test.
+      Value['type'] extends Check
+      ? Value
+      : // Partial test.
+      Value extends Check
+      ? Value
+      : never
+    : never
+
+export type Matches<Value, Check> =
+  // Is this a list?
+  Check extends any[]
+    ? MatchesOne<Value, Check[number]>
+    : MatchesOne<Value, Check>
+
+/* eslint-enable @typescript-eslint/ban-types */

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -45,7 +45,7 @@ type MatchesOne<Value, Check> =
 export type Matches<Value, Check> =
   // Is this a list?
   Check extends any[]
-    ? MatchesOne<Value, Check[number]>
+    ? MatchesOne<Value, Check[keyof Check]>
     : MatchesOne<Value, Check>
 
 /* eslint-enable @typescript-eslint/ban-types */

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -1,12 +1,12 @@
 import type {Node, Parent} from 'unist'
 
-export type NodeInTree<
+export type InclusiveDescendant<
   Tree extends Node = never,
   Found = void
 > = Tree extends Parent
   ?
       | Tree
-      | NodeInTree<
+      | InclusiveDescendant<
           Exclude<Tree['children'][number], Found | Tree>,
           Found | Tree
         >

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -1,5 +1,10 @@
 import type {Node, Parent} from 'unist'
 
-export type NodeInTree<T extends Node, A = void> = T extends Parent
-  ? T | NodeInTree<Exclude<T['children'][number], A | T>, A | T>
-  : T
+export type NodeInTree<Tree extends Node, Found = void> = Tree extends Parent
+  ?
+      | Tree
+      | NodeInTree<
+          Exclude<Tree['children'][number], Found | Tree>,
+          Found | Tree
+        >
+  : Tree

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -1,0 +1,5 @@
+import type {Node, Parent} from 'unist'
+
+export type NodeInTree<T extends Node, A = void> = T extends Parent
+  ? T | NodeInTree<Exclude<T['children'][number], A | T>, A | T>
+  : T

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -1,6 +1,9 @@
 import type {Node, Parent} from 'unist'
 
-export type NodeInTree<Tree extends Node, Found = void> = Tree extends Parent
+export type NodeInTree<
+  Tree extends Node = never,
+  Found = void
+> = Tree extends Parent
   ?
       | Tree
       | NodeInTree<

--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ export const visitParents =
   /**
    * @type {(
    *   (<Needle extends Node>(tree: Node, test: Needle['type']|Partial<Needle>|import('unist-util-is').TestFunctionPredicate<Needle>|Array.<Needle['type']|Partial<Needle>|import('unist-util-is').TestFunctionPredicate<Needle>>, visitor: Visitor<Needle>, reverse?: boolean) => void) &
-   *   (<Tree extends Node>(tree: Tree, test: Test, visitor: Visitor<import('./complex-types').NodeInTree<Tree>>, reverse?: boolean) => void) &
-   *   (<Tree extends Node>(tree: Tree, visitor: Visitor<import('./complex-types').NodeInTree<Tree>>, reverse?: boolean) => void)
+   *   (<Tree extends Node>(tree: Tree, test: Test, visitor: Visitor<import('./complex-types').InclusiveDescendant<Tree>>, reverse?: boolean) => void) &
+   *   (<Tree extends Node>(tree: Tree, visitor: Visitor<import('./complex-types').InclusiveDescendant<Tree>>, reverse?: boolean) => void)
    * )}
    */
   (

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ export const EXIT = false
  * @param tree Abstract syntax tree to walk
  * @param test Test node, optional
  * @param visitor Function to run for each node
- * @param reverse Fisit the tree in reverse, defaults to false
+ * @param reverse Visit the tree in reverse order, defaults to false
  */
 export const visitParents =
   /**

--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ export const EXIT = false
 export const visitParents =
   /**
    * @type {(
-   *   (<Needle extends Node>(tree: Node, test: Needle['type']|Partial<Needle>|import('unist-util-is').TestFunctionPredicate<Needle>|Array.<Needle['type']|Partial<Needle>|import('unist-util-is').TestFunctionPredicate<Needle>>, visitor: Visitor<Needle>, reverse?: boolean) => void) &
-   *   (<Tree extends Node>(tree: Tree, test: Test, visitor: Visitor<import('./complex-types').InclusiveDescendant<Tree>>, reverse?: boolean) => void) &
+   *   (<Tree extends Node, Check extends Test>(tree: Tree, test: Check, visitor: Visitor<import('./complex-types').Matches<import('./complex-types').InclusiveDescendant<Tree>, Check>>, reverse?: boolean) => void) &
    *   (<Tree extends Node>(tree: Tree, visitor: Visitor<import('./complex-types').InclusiveDescendant<Tree>>, reverse?: boolean) => void)
    * )}
    */

--- a/index.js
+++ b/index.js
@@ -48,9 +48,9 @@ export const EXIT = false
 export const visitParents =
   /**
    * @type {(
-   *   (<T extends Node>(tree: Node, test: T['type']|Partial<T>|import('unist-util-is').TestFunctionPredicate<T>|Array.<T['type']|Partial<T>|import('unist-util-is').TestFunctionPredicate<T>>, visitor: Visitor<T>, reverse?: boolean) => void) &
-   *   ((tree: Node, test: Test, visitor: Visitor<Node>, reverse?: boolean) => void) &
-   *   ((tree: Node, visitor: Visitor<Node>, reverse?: boolean) => void)
+   *   (<Needle extends Node>(tree: Node, test: Needle['type']|Partial<Needle>|import('unist-util-is').TestFunctionPredicate<Needle>|Array.<Needle['type']|Partial<Needle>|import('unist-util-is').TestFunctionPredicate<Needle>>, visitor: Visitor<Needle>, reverse?: boolean) => void) &
+   *   (<Tree extends Node>(tree: Tree, test: Test, visitor: Visitor<import('./complex-types').NodeInTree<Tree>>, reverse?: boolean) => void) &
+   *   (<Tree extends Node>(tree: Tree, visitor: Visitor<import('./complex-types').NodeInTree<Tree>>, reverse?: boolean) => void)
    * )}
    */
   (

--- a/index.js
+++ b/index.js
@@ -45,6 +45,14 @@ export const SKIP = 'skip'
  */
 export const EXIT = false
 
+/**
+ * Visit children of tree which pass a test
+ *
+ * @param tree Abstract syntax tree to walk
+ * @param test Test node, optional
+ * @param visitor Function to run for each node
+ * @param reverse Fisit the tree in reverse, defaults to false
+ */
 export const visitParents =
   /**
    * @type {(
@@ -54,12 +62,10 @@ export const visitParents =
    */
   (
     /**
-     * Visit children of tree which pass a test
-     *
-     * @param {Node} tree Abstract syntax tree to walk
-     * @param {Test} test test Test node
-     * @param {Visitor<Node>} visitor Function to run for each node
-     * @param {boolean} [reverse] Fisit the tree in reverse, defaults to false
+     * @param {Node} tree
+     * @param {Test} test
+     * @param {Visitor<Node>} visitor
+     * @param {boolean} [reverse]
      */
     function (tree, test, visitor, reverse) {
       if (typeof test === 'function' && typeof visitor !== 'function') {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-confusing-void-expression, @typescript-eslint/no-empty-function */
 
 import assert from 'node:assert'
-import {expectError} from 'tsd'
+import {expectError, expectType} from 'tsd'
 import {Node, Literal, Parent} from 'unist'
 import {visitParents, SKIP, EXIT, CONTINUE} from './index.js'
 
 /* Setup */
-const sampleTree = {
+const sampleTree: Root = {
   type: 'root',
   children: [{type: 'heading', depth: 1, children: []}]
 }
@@ -85,30 +85,27 @@ expectError(visitParents(sampleTree, 'heading', (_: Element) => {}))
 /* Visit with object test. */
 visitParents(sampleTree, {type: 'heading'}, (_) => {})
 visitParents(sampleTree, {random: 'property'}, (_) => {})
-
 visitParents(sampleTree, {type: 'heading'}, (_: Heading) => {})
 visitParents(sampleTree, {type: 'heading', depth: 2}, (_: Heading) => {})
 expectError(visitParents(sampleTree, {type: 'element'}, (_: Heading) => {}))
 expectError(
   visitParents(sampleTree, {type: 'heading', depth: '2'}, (_: Heading) => {})
 )
-
 visitParents(sampleTree, {type: 'element'}, (_: Element) => {})
 visitParents(
   sampleTree,
   {type: 'element', tagName: 'section'},
   (_: Element) => {}
 )
-
 expectError(visitParents(sampleTree, {type: 'heading'}, (_: Element) => {}))
-
 expectError(
   visitParents(sampleTree, {type: 'element', tagName: true}, (_: Element) => {})
 )
 
 /* Visit with function test. */
-visitParents(sampleTree, headingTest, (_) => {})
-visitParents(sampleTree, headingTest, (_: Heading) => {})
+visitParents(sampleTree, headingTest, (node) => {
+  expectType<Heading>(node)
+})
 expectError(visitParents(sampleTree, headingTest, (_: Element) => {}))
 
 visitParents(sampleTree, elementTest, (_) => {})
@@ -162,10 +159,20 @@ const typedTree: Root = {
   ]
 }
 
-visitParents(typedTree, (_: Root | Flow | Phrasing) => {})
+visitParents(typedTree, (node) => {
+  expectType<Root | Flow | Phrasing>(node)
+})
 const blockquote = typedTree.children[0]
 assert(blockquote.type === 'blockquote')
-visitParents(blockquote, (_: Flow | Phrasing) => {})
+visitParents(blockquote, (node) => {
+  expectType<Flow | Phrasing>(node)
+})
 const paragraph = typedTree.children[1]
 assert(paragraph.type === 'paragraph')
-visitParents(paragraph, (_: Paragraph | Phrasing) => {})
+visitParents(paragraph, (node) => {
+  expectType<Paragraph | Phrasing>(node)
+})
+const emphasis = paragraph.children[1]
+assert(emphasis.type === 'emphasis')
+// To do: error: `flow` cannot exist in phrasing.
+visitParents(emphasis, 'blockquote', (_: Flow) => {})

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -11,6 +11,26 @@ const sampleTree: Root = {
   children: [{type: 'heading', depth: 1, children: []}]
 }
 
+const complexTree: Root = {
+  type: 'root',
+  children: [
+    {
+      type: 'blockquote',
+      children: [{type: 'paragraph', children: [{type: 'text', value: 'a'}]}]
+    },
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'emphasis',
+          children: [{type: 'emphasis', children: [{type: 'text', value: 'b'}]}]
+        },
+        {type: 'text', value: 'c'}
+      ]
+    }
+  ]
+}
+
 interface Element extends Parent {
   type: 'element'
   tagName: string
@@ -18,6 +38,8 @@ interface Element extends Parent {
   content: Node
   children: Node[]
 }
+
+type Content = Flow | Phrasing
 
 interface Root extends Parent {
   type: 'root'
@@ -66,37 +88,27 @@ expectError(visitParents())
 expectError(visitParents(sampleTree))
 
 /* Visit without test. */
-visitParents(sampleTree, (_) => {})
-visitParents(sampleTree, (_: Node) => {})
-expectError(visitParents(sampleTree, (_: Element) => {}))
-expectError(visitParents(sampleTree, (_: Heading) => {}))
+visitParents(sampleTree, (node) => {
+  expectType<Root | Content>(node)
+})
 
 /* Visit with type test. */
-visitParents(sampleTree, 'heading', (_) => {})
-visitParents(sampleTree, 'heading', (_: Heading) => {})
-visitParents(sampleTree, 'not-a-heading', (node) => {
-  // Not in tree.
-  expectType<never>(node)
+visitParents(sampleTree, 'heading', (node) => {
+  expectType<Heading>(node)
 })
 visitParents(sampleTree, 'element', (node) => {
-  // Not in tree.
-  expectType<never>(node)
-})
-
-visitParents(sampleTree, 'element', (_) => {})
-visitParents(sampleTree, 'element', (_: Element) => {})
-visitParents(sampleTree, 'not-an-element', (node) => {
   // Not in tree.
   expectType<never>(node)
 })
 expectError(visitParents(sampleTree, 'heading', (_: Element) => {}))
 
 /* Visit with object test. */
-visitParents(sampleTree, {depth: 1}, (_) => {})
-visitParents(sampleTree, {random: 'property'}, (_) => {})
-visitParents(sampleTree, {depth: 1}, (_: Heading) => {})
-visitParents(sampleTree, {type: 'heading', depth: 2}, (_: Heading) => {})
-expectError(visitParents(sampleTree, {type: 'element'}, (_: Heading) => {}))
+visitParents(sampleTree, {depth: 1}, (node) => {
+  expectType<Heading>(node)
+})
+visitParents(sampleTree, {random: 'property'}, (node) => {
+  expectType<never>(node)
+})
 visitParents(sampleTree, {type: 'heading', depth: '2'}, (node) => {
   // Not in tree.
   expectType<never>(node)
@@ -105,89 +117,59 @@ visitParents(sampleTree, {tagName: 'section'}, (node) => {
   // Not in tree.
   expectType<never>(node)
 })
-visitParents(
-  sampleTree,
-  {type: 'element', tagName: 'section'},
-  (_: Element) => {}
-)
-expectError(visitParents(sampleTree, {type: 'heading'}, (_: Element) => {}))
-visitParents(sampleTree, {type: 'element', tagName: true}, (node) => {
+visitParents(sampleTree, {type: 'element', tagName: 'section'}, (node) => {
   // Not in tree.
   expectType<never>(node)
 })
+expectError(visitParents(sampleTree, {type: 'heading'}, (_: Element) => {}))
 
 /* Visit with function test. */
 visitParents(sampleTree, headingTest, (node) => {
   expectType<Heading>(node)
 })
 expectError(visitParents(sampleTree, headingTest, (_: Element) => {}))
-
-visitParents(sampleTree, elementTest, (_) => {})
-visitParents(sampleTree, elementTest, (_: Element) => {})
 visitParents(sampleTree, elementTest, (node) => {
   // Not in tree.
   expectType<never>(node)
 })
 
 /* Visit with array of tests. */
-visitParents(
-  sampleTree,
-  ['ParagraphNode', {type: 'element'}, headingTest],
-  (_) => {}
-)
-
-/* Visit returns action. */
-visitParents(sampleTree, 'heading', (_) => CONTINUE)
-visitParents(sampleTree, 'heading', (_) => EXIT)
-visitParents(sampleTree, 'heading', (_) => SKIP)
-expectError(visitParents(sampleTree, 'heading', (_) => 'random'))
-
-/* Visit returns index. */
-visitParents(sampleTree, 'heading', (_) => 0)
-visitParents(sampleTree, 'heading', (_) => 1)
-
-/* Visit returns tuple. */
-visitParents(sampleTree, 'heading', (_) => [CONTINUE, 1])
-visitParents(sampleTree, 'heading', (_) => [EXIT, 1])
-visitParents(sampleTree, 'heading', (_) => [SKIP, 1])
-visitParents(sampleTree, 'heading', (_) => [SKIP])
-expectError(visitParents(sampleTree, 'heading', (_) => [1]))
-expectError(visitParents(sampleTree, 'heading', (_) => ['random', 1]))
-
-/* Should infer children from the given tree. */
-
-const typedTree: Root = {
-  type: 'root',
-  children: [
-    {
-      type: 'blockquote',
-      children: [{type: 'paragraph', children: [{type: 'text', value: 'a'}]}]
-    },
-    {
-      type: 'paragraph',
-      children: [
-        {
-          type: 'emphasis',
-          children: [{type: 'emphasis', children: [{type: 'text', value: 'b'}]}]
-        },
-        {type: 'text', value: 'c'}
-      ]
-    }
-  ]
-}
-
-visitParents(typedTree, (node) => {
-  expectType<Root | Flow | Phrasing>(node)
+visitParents(sampleTree, ['heading', {depth: 1}, headingTest], (node) => {
+  // Unfortunately TS casts things in arrays too vague.
+  expectType<Root | Content>(node)
 })
 
-const blockquote = typedTree.children[0]
+/* Visit returns action. */
+visitParents(sampleTree, () => CONTINUE)
+visitParents(sampleTree, () => EXIT)
+visitParents(sampleTree, () => SKIP)
+expectError(visitParents(sampleTree, () => 'random'))
+
+/* Visit returns index. */
+visitParents(sampleTree, () => 0)
+visitParents(sampleTree, () => 1)
+
+/* Visit returns tuple. */
+visitParents(sampleTree, () => [CONTINUE, 1])
+visitParents(sampleTree, () => [EXIT, 1])
+visitParents(sampleTree, () => [SKIP, 1])
+visitParents(sampleTree, () => [SKIP])
+expectError(visitParents(sampleTree, () => [1]))
+expectError(visitParents(sampleTree, () => ['random', 1]))
+
+/* Should infer children from the given tree. */
+visitParents(complexTree, (node) => {
+  expectType<Root | Content>(node)
+})
+
+const blockquote = complexTree.children[0]
 if (is<Blockquote>(blockquote, 'blockquote')) {
   visitParents(blockquote, (node) => {
-    expectType<Flow | Phrasing>(node)
+    expectType<Content>(node)
   })
 }
 
-const paragraph = typedTree.children[1]
+const paragraph = complexTree.children[1]
 if (is<Paragraph>(paragraph, 'paragraph')) {
   visitParents(paragraph, (node) => {
     expectType<Paragraph | Phrasing>(node)

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -74,33 +74,47 @@ expectError(visitParents(sampleTree, (_: Heading) => {}))
 /* Visit with type test. */
 visitParents(sampleTree, 'heading', (_) => {})
 visitParents(sampleTree, 'heading', (_: Heading) => {})
-expectError(visitParents(sampleTree, 'not-a-heading', (_: Heading) => {}))
-expectError(visitParents(sampleTree, 'element', (_: Heading) => {}))
+visitParents(sampleTree, 'not-a-heading', (node) => {
+  // Not in tree.
+  expectType<never>(node)
+})
+visitParents(sampleTree, 'element', (node) => {
+  // Not in tree.
+  expectType<never>(node)
+})
 
 visitParents(sampleTree, 'element', (_) => {})
 visitParents(sampleTree, 'element', (_: Element) => {})
-expectError(visitParents(sampleTree, 'not-an-element', (_: Element) => {}))
+visitParents(sampleTree, 'not-an-element', (node) => {
+  // Not in tree.
+  expectType<never>(node)
+})
 expectError(visitParents(sampleTree, 'heading', (_: Element) => {}))
 
 /* Visit with object test. */
-visitParents(sampleTree, {type: 'heading'}, (_) => {})
+visitParents(sampleTree, {depth: 1}, (_) => {})
 visitParents(sampleTree, {random: 'property'}, (_) => {})
-visitParents(sampleTree, {type: 'heading'}, (_: Heading) => {})
+visitParents(sampleTree, {depth: 1}, (_: Heading) => {})
 visitParents(sampleTree, {type: 'heading', depth: 2}, (_: Heading) => {})
 expectError(visitParents(sampleTree, {type: 'element'}, (_: Heading) => {}))
-expectError(
-  visitParents(sampleTree, {type: 'heading', depth: '2'}, (_: Heading) => {})
-)
-visitParents(sampleTree, {type: 'element'}, (_: Element) => {})
+visitParents(sampleTree, {type: 'heading', depth: '2'}, (node) => {
+  // Not in tree.
+  expectType<never>(node)
+})
+visitParents(sampleTree, {tagName: 'section'}, (node) => {
+  // Not in tree.
+  expectType<never>(node)
+})
 visitParents(
   sampleTree,
   {type: 'element', tagName: 'section'},
   (_: Element) => {}
 )
 expectError(visitParents(sampleTree, {type: 'heading'}, (_: Element) => {}))
-expectError(
-  visitParents(sampleTree, {type: 'element', tagName: true}, (_: Element) => {})
-)
+visitParents(sampleTree, {type: 'element', tagName: true}, (node) => {
+  // Not in tree.
+  expectType<never>(node)
+})
 
 /* Visit with function test. */
 visitParents(sampleTree, headingTest, (node) => {
@@ -110,7 +124,10 @@ expectError(visitParents(sampleTree, headingTest, (_: Element) => {}))
 
 visitParents(sampleTree, elementTest, (_) => {})
 visitParents(sampleTree, elementTest, (_: Element) => {})
-expectError(visitParents(sampleTree, elementTest, (_: Heading) => {}))
+visitParents(sampleTree, elementTest, (node) => {
+  // Not in tree.
+  expectType<never>(node)
+})
 
 /* Visit with array of tests. */
 visitParents(

--- a/package.json
+++ b/package.json
@@ -96,6 +96,10 @@
     "atLeast": 100,
     "detail": true,
     "strict": true,
-    "ignoreCatch": true
+    "ignoreCatch": true,
+    "#": "needed `any`s",
+    "ignoreFiles": [
+      "complex-types.d.ts"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "color.js",
     "color.browser.d.ts",
     "color.browser.js",
+    "complex-types.d.ts",
     "index.d.ts",
     "index.js"
   ],
@@ -50,7 +51,7 @@
     "unist-util-is": "^5.0.0"
   },
   "devDependencies": {
-    "@types/mdast": "^3.0.3",
+    "@types/mdast": "^3.0.0",
     "@types/tape": "^4.0.0",
     "c8": "^7.0.0",
     "prettier": "^2.0.0",
@@ -68,7 +69,7 @@
   },
   "scripts": {
     "prepack": "npm run build && npm run format",
-    "build": "rimraf \"*.d.ts\" && tsc && tsd && type-coverage",
+    "build": "rimraf \"{color,color.browser,index,test}.d.ts\" && tsc && tsd && type-coverage",
     "format": "remark . -qfo && prettier . --write --loglevel warn && xo --fix",
     "test-api": "node test.js",
     "test-coverage": "c8 --check-coverage --branches 100 --functions 100 --lines 100 --statements 100 --reporter lcov node test.js",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "unist-util-is": "^5.0.0"
   },
   "devDependencies": {
+    "@types/hast": "^2.0.0",
     "@types/mdast": "^3.0.0",
     "@types/tape": "^4.0.0",
     "c8": "^7.0.0",

--- a/test.js
+++ b/test.js
@@ -4,6 +4,9 @@
  *
  * @typedef {import('mdast').Root} Root
  * @typedef {import('mdast').Text} Text
+ *
+ * @typedef {import('hast').Root} HastRoot
+ * @typedef {import('hast').Text} HastText
  */
 
 import path from 'node:path'
@@ -629,6 +632,7 @@ test('unist-util-visit-parents', (t) => {
       '\\([^)]+\\' + path.sep + '(\\w+.js):\\d+:\\d+\\)',
       'g'
     )
+    /** @type {HastRoot} */
     const tree = {
       type: 'root',
       children: [
@@ -638,8 +642,8 @@ test('unist-util-visit-parents', (t) => {
           tagName: 'div',
           children: [
             {
-              // A xast-like node.
               type: 'element',
+              // @ts-expect-error: A xast-like node.
               name: 'xml',
               children: [{type: 'text', value: 'Oh no!'}]
             }
@@ -677,7 +681,7 @@ test('unist-util-visit-parents', (t) => {
     t.end()
 
     /**
-     * @param {Text} node
+     * @param {HastText} node
      */
     function fail(node) {
       throw new Error(node.value)

--- a/test.js
+++ b/test.js
@@ -18,7 +18,7 @@ import gfm from 'remark-gfm'
 import {visitParents, EXIT, SKIP, CONTINUE} from './index.js'
 
 /** @type {Root} */
-// @ts-expect-error: hush.
+// @ts-expect-error: return type is known to be `Root`.
 const tree = remark().parse('Some _emphasis_, **importance**, and `code`.')
 const paragraph = tree.children[0]
 assert(paragraph.type === 'paragraph')

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
  * @typedef {import('unist').Node} Node
  * @typedef {import('unist').Parent} Parent
  *
+ * @typedef {import('mdast').Root} Root
  * @typedef {import('mdast').Text} Text
  */
 
@@ -13,9 +14,15 @@ import remark from 'remark'
 import gfm from 'remark-gfm'
 import {visitParents, EXIT, SKIP, CONTINUE} from './index.js'
 
-const tree = remark().parse('Some _emphasis_, **importance**, and `code`.')
+/** @type {Root} */
 // @ts-expect-error: hush.
+const tree = remark().parse('Some _emphasis_, **importance**, and `code`.')
 const paragraph = tree.children[0]
+assert(paragraph.type === 'paragraph')
+const emphasis = paragraph.children[1]
+assert(emphasis.type === 'emphasis')
+const strong = paragraph.children[3]
+assert(strong.type === 'strong')
 
 const textNodes = 6
 
@@ -28,10 +35,10 @@ const types = [
   'paragraph', // [tree]
   'text', // [tree, paragraph]
   'emphasis', // [tree, paragraph]
-  'text', // [tree, paragraph, paragraph.children[1]]
+  'text', // [tree, paragraph, emphasis]
   'text', // [tree, paragraph]
   'strong', // [tree, paragraph]
-  'text', // [tree, paragraph, paragraph.children[3]]
+  'text', // [tree, paragraph, strong]
   'text', // [tree, paragraph]
   'inlineCode', // [tree, paragraph]
   'text' // [tree, paragraph]
@@ -57,10 +64,10 @@ const ancestors = [
   [tree],
   [tree, paragraph],
   [tree, paragraph],
-  [tree, paragraph, paragraph.children[1]],
+  [tree, paragraph, emphasis],
   [tree, paragraph],
   [tree, paragraph],
-  [tree, paragraph, paragraph.children[3]],
+  [tree, paragraph, strong],
   [tree, paragraph],
   [tree, paragraph],
   [tree, paragraph]
@@ -69,9 +76,9 @@ const ancestors = [
 /** @type {Array.<Array.<Parent>>} */
 const textAncestors = [
   [tree, paragraph],
-  [tree, paragraph, paragraph.children[1]],
+  [tree, paragraph, emphasis],
   [tree, paragraph],
-  [tree, paragraph, paragraph.children[3]],
+  [tree, paragraph, strong],
   [tree, paragraph],
   [tree, paragraph]
 ]


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

While the signature `visitParents(tree, 'emphasis', (node: Emphasis) => void)` already works (that is, assuming that the tree could potentially include an emphasis node, so not hast, and that the tree does not include an `type: emphasis` which is otherwise different from `Emphasis`), the other signatures were not as smart.

Given

```
const root: Root = {...}
visitParent(root, (node: ?) => {})
```

`?` is now filled with any node that is `root` or (recursively) in `root.children`.

EDIT: this now also figures out the signature *with* a test!

<!--do not edit: pr-->
